### PR TITLE
Add export route for uploads and E2E tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  run-ci:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: docker
+          POSTGRES_PASSWORD: docker
+          POSTGRES_DB: upload_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test

--- a/src/app/functions/export-uploads.spec.ts
+++ b/src/app/functions/export-uploads.spec.ts
@@ -1,11 +1,34 @@
 import { randomUUID } from 'node:crypto'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import * as upload from '@/infra/storage/upload-file-to-storage'
 import { isRight, unwrapEither } from '@/shared/either'
 import { makeUpload } from '@/test/factories/make-upload'
 import { exportUploads } from './export-uploads'
 
 describe('export uploads', () => {
+  // beforeAll(() => {
+  //   vi.mock('@/infra/storage/upload-file-to-storage', () => {
+  //     return {
+  //       uploadFileToStorage: vi.fn().mockImplementation(() => {
+  //         return {
+  //           key: `${randomUUID()}.jpg`,
+  //           url: 'https://storage.com/image.jpg',
+  //         }
+  //       }),
+  //     }
+  //   })
+  // })
+
   it('should be able to export uploads', async () => {
+    const uploadStub = vi
+      .spyOn(upload, 'uploadFileToStorage')
+      .mockImplementationOnce(async () => {
+        return {
+          key: `${randomUUID()}.csv`,
+          url: 'https://example.com/file.csv',
+        }
+      })
+
     const namePattern = randomUUID()
 
     const upload1 = await makeUpload({ name: `${namePattern}.webp` })
@@ -18,6 +41,40 @@ describe('export uploads', () => {
       searchQuery: namePattern,
     })
 
+    const generatedCSVStream = uploadStub.mock.calls[0][0].contentStream
+
+    const csvAsString = await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = []
+
+      generatedCSVStream.on('data', (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+
+      generatedCSVStream.on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf-8'))
+      })
+
+      generatedCSVStream.on('error', err => {
+        reject(err)
+      })
+    })
+
+    const csvAsArray = csvAsString
+      .trim()
+      .split('\n')
+      .map(row => row.split(','))
+
     expect(isRight(sut)).toBe(true)
+    expect(unwrapEither(sut)).toEqual({
+      reportUrl: 'https://example.com/file.csv',
+    })
+    expect(csvAsArray).toEqual([
+      ['ID', 'Name', 'URL', 'Uploaded at'],
+      [upload1.id, upload1.name, upload1.remoteUrl, expect.any(String)],
+      [upload2.id, upload2.name, upload2.remoteUrl, expect.any(String)],
+      [upload3.id, upload3.name, upload3.remoteUrl, expect.any(String)],
+      [upload4.id, upload4.name, upload4.remoteUrl, expect.any(String)],
+      [upload5.id, upload5.name, upload5.remoteUrl, expect.any(String)],
+    ])
   })
 })

--- a/src/infra/http/routes/export-uploads.ts
+++ b/src/infra/http/routes/export-uploads.ts
@@ -1,0 +1,35 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { z } from 'zod'
+import { exportUploads } from '@/app/functions/export-uploads'
+import { unwrapEither } from '@/shared/either'
+
+export const exportUploadsRoute: FastifyPluginAsyncZod = async server => {
+  server.get(
+    '/uploads/exports',
+    {
+      schema: {
+        summary: 'Export uploads',
+        tags: ['uploads'],
+        querystring: z.object({
+          searchQuery: z.string().optional(),
+        }),
+        response: {
+          200: z.object({
+            reportUrl: z.url(),
+          }),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { searchQuery } = request.query
+
+      const result = await exportUploads({
+        searchQuery,
+      })
+
+      const { reportUrl } = unwrapEither(result)
+
+      return reply.status(200).send({ reportUrl })
+    }
+  )
+}

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -8,6 +8,7 @@ import {
   serializerCompiler,
   validatorCompiler,
 } from 'fastify-type-provider-zod'
+import { exportUploadsRoute } from './routes/export-uploads'
 import { getUploadsRoute } from './routes/get-uploads'
 import { uploadImageRoute } from './routes/upload-image'
 import { transformSwaggerSchema } from './transform-swagger-schema'
@@ -48,6 +49,7 @@ server.register(fastifySwaggerUi, { routePrefix: '/docs' })
 
 server.register(uploadImageRoute)
 server.register(getUploadsRoute)
+server.register(exportUploadsRoute)
 
 server.listen({ port: 3333, host: '0.0.0.0' }).then(() => {
   console.log('HTTP server running!')


### PR DESCRIPTION
Introduce a new route for exporting uploads and implement end-to-end tests to ensure functionality.